### PR TITLE
LIBFCREPO-1078. Enable remote JMX over port 11099.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,15 @@ COPY activemq/env $ACTIVEMQ_HOME/bin/env
 
 VOLUME /var/opt/activemq
 VOLUME /var/log/fixity
+
+# STOMP
 EXPOSE 61613
+# OpenWire
 EXPOSE 61616
+# HTTP admin console
 EXPOSE 8161
+# JMX
+EXPOSE 11099
 
 WORKDIR $ACTIVEMQ_HOME
 CMD ["bin/activemq", "console"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This image is based on the [OpenJDK 8 Docker base image], and runs
 |Port number|Purpose|
 |-----------|-------|
 |8161       |ActiveMQ web admin console|
+|11099      |[JMX] remote connection|
 |61613      |[STOMP] messaging|
 |61616      |[OpenWire] messaging|
 
@@ -89,3 +90,5 @@ See the [LICENSE](LICENSE) file for license rights and limitations (Apache 2.0).
 [OpenJDK 8 Docker base image]: https://hub.docker.com/_/openjdk
 [ActiveMQ 5.16.0]: https://activemq.apache.org/activemq-5016000-release
 [umd-camel-processors 1.0.0]: https://github.com/umd-lib/umd-camel-processors/tree/1.0.0
+[fabric8io docker-maven-plugin]: https://dmp.fabric8.io/
+[JMX]: https://activemq.apache.org/jmx#activemq-mbeans-reference

--- a/activemq/env
+++ b/activemq/env
@@ -48,7 +48,7 @@ fi
 # This enables jmx access over a configured jmx-tcp-port.
 # You have to configure the first four settings if you run a ibm jvm, caused by the
 # fact that IBM's jvm does not support VirtualMachine.attach(PID).
-# JMX access is needed for quering a running activemq instance to gain data or to
+# JMX access is needed for querying a running activemq instance to gain data or to
 # trigger management operations.
 #
 # Example for ${ACTIVEMQ_CONF}/jmx.access:
@@ -67,10 +67,11 @@ fi
 # controlRole abcd1234
 # ---
 #
-# ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.port=11099 "
+ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.port=11099"
 # ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.password.file=${ACTIVEMQ_CONF}/jmx.password"
 # ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.access.file=${ACTIVEMQ_CONF}/jmx.access"
-# ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.ssl=false"
+ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.ssl=false"
+ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote.authenticate=false"
 ACTIVEMQ_SUNJMX_START="$ACTIVEMQ_SUNJMX_START -Dcom.sun.management.jmxremote"
 
 # Set jvm jmx configuration for controlling the broker process


### PR DESCRIPTION
Set up with no SSL and no password, so this connection should ONLY be used internally, and not exposed to the public internet.

https://issues.umd.edu/browse/LIBFCREPO-1078