### PR TITLE
LIBFCREPO-1100. Remove HTTP Client 4.5.11 from the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ ENV ACTIVEMQ_HOME /opt/apache-activemq-${ACTIVEMQ_VERSION}
 ENV ACTIVEMQ_DATA /var/opt/activemq
 ENV ACTIVEMQ_MAX_DISK 16G
 
+# remove httpclient 4.5.11 that is bundled with ActiveMQ, because we need to
+# make sure we are using 4.5.12+ to properly follow 308 redirects
+# use the "-f" flag to avoid failing the build if the file doesn't exist
+RUN rm -f $ACTIVEMQ_HOME/lib/optional/httpclient-4.5.11.jar
+
 COPY --from=dependencies /var/jars/target/dependency/*.jar $ACTIVEMQ_HOME/lib/optional/
 
 COPY activemq/conf $ACTIVEMQ_HOME/conf/

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <camel.version>2.25.2</camel.version>
     <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
     <postgresql.version>42.2.16</postgresql.version>
-    <umd-camel-processors.version>1.0.1</umd-camel-processors.version>
+    <umd-camel-processors.version>1.1.0-SNAPSHOT</umd-camel-processors.version>
   </properties>
 
   <distributionManagement>
@@ -57,6 +57,13 @@
   </repositories>
 
   <dependencies>
+    <dependency>
+      <!-- must use httpclient 4.5.12+, so it will handle 308 redirects correctly -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
+    </dependency>
+
     <!-- PostgreSQL -->
     <dependency>
       <groupId>org.postgresql</groupId>


### PR DESCRIPTION
This is the version bundled with ActiveMQ 5.16 that does not follow 308 redirects. Use the 1.1.0-SNAPSHOT version of umd-camel-processors, which uses Apache HTTP Client 4.5.13.

https://issues.umd.edu/browse/LIBFCREPO-1100