### PR TITLE
LIBFCREPO-1104. Remove duplicated LDPath definition for the component field.

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -119,8 +119,6 @@ annotation_motivation = oa:motivatedBy :: xsd:string;
 resource_selector = oa:hasTarget/oa:hasSelector[rdf:type is oa:FragmentSelector]/rdf:value :: xsd:string;
 
 issue_title_facet = .[rdf:type is bibo:Issue]/dcterms:title | pcdm:memberOf[rdf:type is bibo:Issue]/dcterms:title :: xsd:string;
-
-component = edm:hasType/rdfs:label :: xsd:string;
       ]]></value>
     </property>
   </bean>


### PR DESCRIPTION
Having two instances of the field definition appears to cause the field not to get written at all.

https://issues.umd.edu/browse/LIBFCREPO-1104