### PR TITLE
LIBFCREPO-1117. Bumped umd-camel-processors version to 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <camel.version>2.25.2</camel.version>
     <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
     <postgresql.version>42.2.16</postgresql.version>
-    <umd-camel-processors.version>1.1.0</umd-camel-processors.version>
+    <umd-camel-processors.version>1.1.2</umd-camel-processors.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
That version fixes the NullPointerException when retrieving resources without a "describedby" link header for indexing.

https://issues.umd.edu/browse/LIBFCREPO-1117