### PR TITLE
LIBFCREPO-1249. Pin the Spring framework version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
     <postgresql.version>42.2.16</postgresql.version>
     <umd-camel-processors.version>1.1.3</umd-camel-processors.version>
+    <spring.version>5.3.16</spring.version>
   </properties>
 
   <distributionManagement>
@@ -55,6 +56,19 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- standardize the Spring versions across dependencies -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Use the spring-framework-bom BOM to pin the version of Spring across all dependencies.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1249