### PR TITLE
LIBFCREPO-1280. Fix the audit.log file path in log4j config.

### DIFF
--- a/activemq/conf/jetty.xml
+++ b/activemq/conf/jetty.xml
@@ -65,11 +65,13 @@ e.g. <import resource="jetty.xml"/>
           <property name="contextPath" value="/admin" />
           <property name="resourceBase" value="${activemq.home}/webapps/admin" />
           <property name="logUrlOnStart" value="true" />
+          <property name="tempDirectory" value="/tmp/webapps/admin" />
         </bean>
         <bean class="org.eclipse.jetty.webapp.WebAppContext">
           <property name="contextPath" value="/api" />
           <property name="resourceBase" value="${activemq.home}/webapps/api" />
           <property name="logUrlOnStart" value="true" />
+          <property name="tempDirectory" value="/tmp/webapps/api" />
         </bean>
         <bean class="org.eclipse.jetty.server.handler.ResourceHandler">
           <property name="directoriesListed" value="false" />

--- a/activemq/conf/log4j.properties
+++ b/activemq/conf/log4j.properties
@@ -5,9 +5,9 @@
 ## The ASF licenses this file to You under the Apache License, Version 2.0
 ## (the "License"); you may not use this file except in compliance with
 ## the License.  You may obtain a copy of the License at
-## 
+##
 ## http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 ## ---------------------------------------------------------------------------
 
 #
-# This file controls most of the logging in ActiveMQ which is mainly based around 
+# This file controls most of the logging in ActiveMQ which is mainly based around
 # the commons logging API.
 #
 log4j.rootLogger=WARN, console
@@ -73,7 +73,7 @@ log4j.additivity.org.apache.activemq.audit=false
 log4j.logger.org.apache.activemq.audit=INFO, audit
 
 log4j.appender.audit=org.apache.log4j.RollingFileAppender
-log4j.appender.audit.file=${activemq.base}/data/audit.log
+log4j.appender.audit.file=${activemq.data}/audit.log
 log4j.appender.audit.maxFileSize=1024KB
 log4j.appender.audit.maxBackupIndex=5
 log4j.appender.audit.append=true


### PR DESCRIPTION
Use `${activemq.data}` instead of `${activemq.base}/data` in log4j.properties.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1280