### PR TITLE
LIBFCREPO-1341. Added Solr indexing for terms_of_use

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -97,6 +97,7 @@ geoname = fn:first(dcterms:spatial/owl:sameAs, dcterms:spatial) :: xsd:string;
 subject = dcterms:subject/rdfs:label | dc:subject :: xsd:string;
 genre = edm:hasType :: xsd:string;
 rights = dcterms:rights :: xsd:string;
+terms_of_use_text = dcterms:license/rdf:value :: xsd:string;
 copyright_notice = schema:copyrightNotice :: xsd:string;
 
 issue_volume = bibo:volume :: xsd:string;


### PR DESCRIPTION
Update ldpath to include terms_of_use (as "terms_of_use_text", as it stores the humand-readable text of them vocabulary term)for Solr indexing.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1341