### PR TITLE
LIBFCREPO-1431. Changed "schema" prefix to "https://schema.org/"

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -42,7 +42,7 @@
 @prefix ldp: <http://www.w3.org/ns/ldp#>
 @prefix umdtype: <http://vocab.lib.umd.edu/datatype#>
 @prefix ore: <http://www.openarchives.org/ore/terms/>
-@prefix schema: <http://schema.org/>
+@prefix schema: <https://schema.org/>
 
 id = . :: xsd:string ;
 rdf_type = rdf:type :: xsd:string;


### PR DESCRIPTION
Changed the "schema" prefix from "http://schema.org/" to "https://schema.org/" as "https" is the protocol used in the canonical URLs on the schema.org website.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1431