### PR TITLE
LIBFCREPO-1582. Differentiate between "create" and "import" events.

### DIFF
--- a/activemq/conf/camel/audit.xml
+++ b/activemq/conf/camel/audit.xml
@@ -41,6 +41,18 @@
           </setHeader>
         </when>
         <when>
+          <simple>${headers.CamelFcrepoEventName} == "import binary"</simple>
+          <setHeader headerName="CamelAuditEventType">
+            <constant>http://id.loc.gov/vocabulary/preservation/eventType/ing</constant>
+          </setHeader>
+        </when>
+        <when>
+          <simple>${headers.CamelFcrepoEventName} == "import RDF"</simple>
+          <setHeader headerName="CamelAuditEventType">
+            <constant>http://id.loc.gov/vocabulary/preservation/eventType/cre</constant>
+          </setHeader>
+        </when>
+        <when>
           <simple>${headers.CamelFcrepoEventName} == "update binary"</simple>
           <setHeader headerName="CamelAuditEventType">
             <constant>http://fedora.info/definitions/v4/audit#contentModification</constant>

--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -39,6 +39,19 @@
       <setHeader headerName="CamelFcrepoPath">
         <header>org.fcrepo.jms.identifier</header>
       </setHeader>
+      <setHeader headerName="CamelFcrepoTopLevelResourcePath">
+        <description>extracts the repo path from the top-level resource that the
+        current resource is a part of (or is)</description>
+        <groovy>
+          def match = (headers["CamelFcrepoPath"] =~ $/(/dc/\d{4}/\d+/../../../../.{8}-.{4}-.{4}-.{4}-.{12})/$)
+          if (match) {
+            result = match[0][1]
+          }
+        </groovy>
+      </setHeader>
+      <setHeader headerName="UMDIsTopLevelResource">
+        <simple resultType="java.lang.Boolean">${header.CamelFcrepoPath} == ${header.CamelFcrepoTopLevelResourcePath}</simple>
+      </setHeader>
       <log loggingLevel="DEBUG" message="Event user: ${header.CamelFcrepoUser}"/>
       <log loggingLevel="DEBUG" message="Event user agent: ${header.CamelFcrepoUserAgent}"/>
       <log loggingLevel="INFO" message="Routing event for resource with URI: ${header.CamelFcrepoUri}"/>
@@ -94,19 +107,31 @@
     <!--
     Expected headers:
     * CamelFcrepoEventType
+    * CamelFcrepoUserAgent
     -->
     <route id="edu.umd.lib.camel.routes.DetectEventType">
       <from uri="direct:detectEventType"/>
       <log loggingLevel="DEBUG" message="${routeId}: ${id}"/>
+
       <choice>
         <when>
           <simple>
             ${header.CamelFcrepoEventType} contains "http://fedora.info/definitions/v4/event#ResourceCreation"
             || ${header.CamelFcrepoEventType} contains "https://www.w3.org/ns/activitystreams#Create"
           </simple>
-          <setHeader headerName="CamelFcrepoEventName">
-            <constant>create</constant>
-          </setHeader>
+          <choice>
+            <when>
+              <simple>${header.CamelFcrepoUserAgent} contains '(import)'</simple>
+              <setHeader headerName="CamelFcrepoEventName">
+                <constant>import</constant>
+              </setHeader>
+            </when>
+            <otherwise>
+              <setHeader headerName="CamelFcrepoEventName">
+                <constant>create</constant>
+              </setHeader>
+            </otherwise>
+          </choice>
         </when>
         <when>
           <simple>
@@ -127,6 +152,7 @@
           </setHeader>
         </when>
       </choice>
+
       <to uri="direct:detectBinary"/>
     </route>
 
@@ -215,7 +241,7 @@
             if the message is about a new binary, remove all headers except for CamelFcrepoUri,
             clear the body, and send to the fixity candidates queue
           -->
-          <simple>${header.CamelFcrepoEventName} == "create binary"</simple>
+          <simple>${header.CamelFcrepoEventName} in "create binary,import binary"</simple>
           <log loggingLevel="INFO" message="New binary detected, sending to fixity candidates queue"/>
           <!-- clean out unnecessary headers (just leave the fcrepo URI), and clear the body -->
           <removeHeaders pattern="*" excludePattern="CamelFcrepoUri"/>

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -194,14 +194,28 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <description>delete event</description>
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
           <to uri="direct:solr.delete"/>
+          <to uri="direct:solr.update"/>
         </when>
-        <otherwise>
+        <when>
+          <description>import event</description>
+          <simple>${header.CamelFcrepoEventName} starts with "import"</simple>
+          <!-- filter out non-top-level resources when indexing after an import
+               since Solrizer will include the child resources itself -->
+          <filter>
+            <simple>${header.UMDIsTopLevelResource}</simple>
+            <to uri="direct:solr.solrizer"/>
+            <to uri="direct:solr.add"/>
+            <to uri="direct:solr.update"/>
+          </filter>
+        </when>
+        <when>
+          <description>create event</description>
+          <simple>${header.CamelFcrepoEventName} starts with "create"</simple>
           <to uri="direct:solr.solrizer"/>
           <to uri="direct:solr.add"/>
-        </otherwise>
+          <to uri="direct:solr.update"/>
+        </when>
       </choice>
-
-      <to uri="direct:solr.update"/>
     </route>
 
     <route id="edu.umd.lib.camel.routes.LDPathTransformation">
@@ -245,7 +259,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         `{"add": {"doc": {...}}}` structure.</description>
       <from uri="direct:solr.add"/>
 
-      <log loggingLevel="INFO" message="Indexing ${header.CamelFcrepoUri} to Solr"/>
+      <log loggingLevel="INFO" message="Creating Solr add command for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="Content-Type">
         <constant>application/json</constant>
       </setHeader>
@@ -259,7 +273,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         resource with the `id` found in the `CamelFcrepoUri` header.</description>
       <from uri="direct:solr.delete"/>
 
-      <log loggingLevel="INFO" message="Deleting Solr index record for ${header.CamelFcrepoUri}"/>
+      <log loggingLevel="INFO" message="Creating Solr delete command for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="Content-Type">
         <constant>application/json</constant>
       </setHeader>
@@ -270,7 +284,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
 
     <route id="edu.umd.lib.camel.routes.SendSolrUpdate">
       <description>Sends a Solr command (in the message body) to the URL in the
-      `SolrUpdateEndpoint` header as an HTTP POST request.</description>
+        `SolrUpdateEndpoint` header as an HTTP POST request.</description>
       <from uri="direct:solr.update"/>
 
       <log loggingLevel="DEBUG" message="Sending ${body} to ${header.SolrUpdateEndpoint}"/>


### PR DESCRIPTION
* an import event is a create event that is performed by a User-Agent identifying itself using the string "(import)"
* import events are filtered in the Solrizer indexer down to just top-level resources, since Solrizer will fill in all the child document data itself
* clarify logging messages when constructing the add and delete command messages

https://umd-dit.atlassian.net/browse/LIBFCREPO-1582