### PR TITLE
LIBFCREPO-1110. Added an onException clause for catching routing errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ UMD Libraries Fedora Messaging Infrastructure
 
 ## Related Repositories
 
-* [umd-camel-processors](https://github.com/umd-lib/umd-camel-processors)
-* [umd-fcrepo-docker]
+* [umd-camel-processors]
+* [umd-fcrepo-auth-utils]
 
 ## Camel Routes
 
@@ -21,24 +21,21 @@ UMD Libraries Fedora Messaging Infrastructure
 
 This repository contains a [Dockerfile](Dockerfile) for creating a Docker image.
 
-This image is based on the [OpenJDK 8 Docker base image], and runs
-[ActiveMQ 5.16.0] with [umd-camel-processors 1.0.0].
-
 ### Volumes
 
-|Mount point|Purpose|
-|-----------|-------|
-|`/var/opt/activemq`|Persistent data for ActiveMQ (queues, logs, etc.)|
-|`/var/log/fixity`  |Fixity check logs (see the [fixity Camel route])|
+| Mount point         | Purpose                                           |
+|---------------------|---------------------------------------------------|
+| `/var/opt/activemq` | Persistent data for ActiveMQ (queues, logs, etc.) |
+| `/var/log/fixity`   | Fixity check logs (see the [fixity Camel route])  |
 
 ### Ports
 
-|Port number|Purpose|
-|-----------|-------|
-|8161       |ActiveMQ web admin console|
-|11099      |[JMX] remote connection|
-|61613      |[STOMP] messaging|
-|61616      |[OpenWire] messaging|
+| Port number | Purpose                    |
+|-------------|----------------------------|
+| 8161        | ActiveMQ web admin console |
+| 11099       | [JMX] remote connection    |
+| 61613       | [STOMP] messaging          |
+| 61616       | [OpenWire] messaging       |
 
 ### Build
 
@@ -94,8 +91,7 @@ See the [LICENSE](LICENSE) file for license rights and limitations (Apache 2.0).
 [fixity Camel route]: activemq/conf/camel/fixity.xml
 [STOMP]: https://stomp.github.io/
 [OpenWire]: https://activemq.apache.org/openwire.html
-[OpenJDK 8 Docker base image]: https://hub.docker.com/_/openjdk
-[ActiveMQ 5.16.0]: https://activemq.apache.org/activemq-5016000-release
-[umd-camel-processors 1.0.0]: https://github.com/umd-lib/umd-camel-processors/tree/1.0.0
+[umd-camel-processors]: https://github.com/umd-lib/umd-camel-processors
+[umd-fcrepo-auth-utils]: https://github.com/umd-lib/umd-fcrepo-auth-utils
 [fabric8io docker-maven-plugin]: https://dmp.fabric8.io/
 [JMX]: https://activemq.apache.org/jmx#activemq-mbeans-reference

--- a/activemq/conf/activemq.xml
+++ b/activemq/conf/activemq.xml
@@ -156,7 +156,7 @@
   <!-- Camel Routing -->
   <import resource="camel/routes.xml"/>
   <import resource="camel/indexing.xml"/>
-  <import resource="camel/audit.xml"/>
+  <import resource="camel/auditing.xml"/>
   <import resource="camel/fixity.xml"/>
   <import resource="camel/triplestore.xml"/>
   <import resource="camel/solr.xml"/>

--- a/activemq/conf/activemq.xml
+++ b/activemq/conf/activemq.xml
@@ -152,10 +152,59 @@
   <bean id="repoExternalURL" class="java.net.URL">
     <constructor-arg value="${REPO_EXTERNAL_URL}"/>
   </bean>
+
+  <!-- Camel Routing -->
   <import resource="camel/routes.xml"/>
   <import resource="camel/indexing.xml"/>
   <import resource="camel/audit.xml"/>
   <import resource="camel/fixity.xml"/>
   <import resource="camel/triplestore.xml"/>
   <import resource="camel/solr.xml"/>
+
+  <!-- must enable stream caching since multiple downstream endpoints need to each read the message body in parallel -->
+  <camelContext xmlns="http://camel.apache.org/schema/spring" id="fcrepo" streamCache="true">
+    <routeContextRef ref="EventProcessing"/>
+    <routeContextRef ref="Indexing"/>
+    <routeContextRef ref="Auditing"/>
+    <routeContextRef ref="FixityChecking"/>
+    <routeContextRef ref="Solr"/>
+    <routeContextRef ref="Triplestore"/>
+
+    <onException>
+      <exception>java.lang.Exception</exception>
+      <handled>
+        <constant>true</constant>
+      </handled>
+      <!-- add some extra error diagnostics to the headers -->
+      <setHeader headerName="CamelFailureRouteId">
+        <exchangeProperty>CamelFailureRouteId</exchangeProperty>
+      </setHeader>
+      <setHeader headerName="CamelFailureEndpoint">
+        <exchangeProperty>CamelFailureEndpoint</exchangeProperty>
+      </setHeader>
+      <setHeader headerName="CamelExceptionMessage">
+        <simple>${exchangeProperty.CamelExceptionCaught.message}</simple>
+      </setHeader>
+      <setHeader headerName="CamelExceptionStackTrace">
+        <groovy>
+          import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace
+          result = getStackTrace(exchange.getProperty("CamelExceptionCaught"))
+        </groovy>
+      </setHeader>
+      <setHeader headerName="JMSCorrelationID">
+        <groovy>UUID.randomUUID().toString()</groovy>
+      </setHeader>
+      <log loggingLevel="ERROR" message="Failed endpoint: ${header.CamelFailureEndpoint}"/>
+      <log loggingLevel="ERROR" message="${header.CamelExceptionMessage}"/>
+      <setProperty propertyName="errorQueue">
+        <groovy>"activemq:errors." + headers["CamelFailureRouteId"].replace("edu.umd.lib.camel.", "", )</groovy>
+      </setProperty>
+      <log loggingLevel="ERROR" message="Message routed to ${exchangeProperty.errorQueue} with JMS Correlation ID ${header.JMSCorrelationID}"/>
+      <recipientList>
+        <exchangeProperty>errorQueue</exchangeProperty>
+      </recipientList>
+      <stop/>
+    </onException>
+
+  </camelContext>
 </beans>

--- a/activemq/conf/camel/audit.xml
+++ b/activemq/conf/camel/audit.xml
@@ -11,8 +11,7 @@
     <property name="password" value="${AUDIT_DB_PASSWORD}"/>
   </bean>
 
-  <camelContext xmlns="http://camel.apache.org/schema/spring" id="Auditing" streamCache="true">
-
+  <routeContext xmlns="http://camel.apache.org/schema/spring" id="Auditing">
     <!--
     Expected headers:
     * CamelFcrepoUri
@@ -159,6 +158,6 @@
       <to uri="http4:triplestore"/>
     </route>
 
-  </camelContext>
+  </routeContext>
 
 </beans>

--- a/activemq/conf/camel/auditing.xml
+++ b/activemq/conf/camel/auditing.xml
@@ -20,8 +20,8 @@
     Expected environment variables:
     * AUDIT_EVENT_BASE_URI
     -->
-    <route id="edu.umd.lib.camel.routes.Audit">
-      <from uri="activemq:queue:audit"/>
+    <route id="edu.umd.lib.camel.routes.queue.audit">
+      <from uri="activemq:audit"/>
       <log loggingLevel="DEBUG" message="Receiving audit event for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="CamelAuditEventUri">
         <simple>${sysenv.AUDIT_EVENT_BASE_URI}${header.CamelFcrepoEventId}</simple>
@@ -78,8 +78,8 @@
       </choice>
       <log loggingLevel="DEBUG" message="Event type for PREMIS: ${header.CamelAuditEventType}"/>
       <multicast parallelProcessing="true">
-        <to uri="direct:generatePremis"/>
-        <to uri="activemq:queue:audit.database"/>
+        <to uri="direct:auditing.GeneratePremis"/>
+        <to uri="activemq:audit.database"/>
       </multicast>
     </route>
 
@@ -91,8 +91,8 @@
     * CamelFcrepoUserAgent
     * CamelAuditEventType
     -->
-    <route id="edu.umd.lib.camel.routes.GeneratePremis">
-      <from uri="direct:generatePremis"/>
+    <route id="edu.umd.lib.camel.routes.auditing.GeneratePremis">
+      <from uri="direct:auditing.GeneratePremis"/>
       <setBody>
         <simple><![CDATA[
 <${header.CamelAuditEventUri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/audit#InternalEvent> .
@@ -121,8 +121,8 @@
     Expected beans:
     * auditDatabase : javax.sql.DataSource
     -->
-    <route id="edu.umd.lib.camel.routes.AuditDatabase">
-      <from uri="activemq:queue:audit.database"/>
+    <route id="edu.umd.lib.camel.routes.queue.audit.database">
+      <from uri="activemq:audit.database"/>
       <setBody>
         <constant><![CDATA[
           INSERT INTO history (event_uri, event_type, username, resource_uri, timestamp)
@@ -140,8 +140,8 @@
     Expected environment variables:
     * AUDIT_TRIPLESTORE_UPDATE_URI
     -->
-    <route id="edu.umd.lib.camel.routes.AuditTriplestore">
-      <from uri="activemq:queue:audit.triplestore"/>
+    <route id="edu.umd.lib.camel.routes.queue.audit.triplestore">
+      <from uri="activemq:audit.triplestore"/>
       <removeHeaders pattern="*"/>
       <setHeader headerName="Content-Type">
         <constant>application/sparql-update</constant>

--- a/activemq/conf/camel/fixity.xml
+++ b/activemq/conf/camel/fixity.xml
@@ -60,9 +60,7 @@
     <property name="resultsFormatName" value="csvWithoutHeader"/>
   </bean>
 
-  <!-- must enable stream caching since multiple downstream endpoints need to each read the message body in parallel -->
-  <camelContext xmlns="http://camel.apache.org/schema/spring" id="FixityChecking" streamCache="true">
-
+  <routeContext xmlns="http://camel.apache.org/schema/spring" id="FixityChecking">
     <!--
     Expects headers:
     * CamelFcrepoPath
@@ -233,6 +231,6 @@
       </routingSlip>
     </route>
 
-  </camelContext>
+  </routeContext>
 
 </beans>

--- a/activemq/conf/camel/fixity.xml
+++ b/activemq/conf/camel/fixity.xml
@@ -73,8 +73,8 @@
     * addBearerAuthorization : edu.umd.lib.camel.processors.AddBearerAuthorizationProcessor
     * repoExternalURL : java.net.URL
     -->
-    <route id="edu.umd.lib.camel.routes.FixityChecker">
-      <from uri="activemq:queue:fixity"/>
+    <route id="edu.umd.lib.camel.routes.queue.fixity">
+      <from uri="activemq:fixity"/>
       <setHeader headerName="CamelHttpUri">
         <simple>${sysenv.REPO_INTERNAL_URL}${header.CamelFcrepoPath}</simple>
       </setHeader>
@@ -114,30 +114,30 @@
           <when>
             <xpath>/rdf:RDF/rdf:Description/premis:hasEventOutcome[text()='SUCCESS']</xpath>
             <log loggingLevel="INFO" message="Fixity check succeeded for ${header.CamelFcrepoUri}"/>
-            <to uri="direct:fixity.success"/>
+            <to uri="direct:fixity.SuccessDistribution"/>
           </when>
           <otherwise>
             <log loggingLevel="INFO" message="Fixity check failed for ${header.CamelFcrepoUri}"/>
-            <to uri="direct:fixity.failure"/>
+            <to uri="direct:fixity.FailureDistribution"/>
           </otherwise>
         </choice>
       </filter>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.FixitySuccessDistribution">
-      <from uri="direct:fixity.success"/>
+    <route id="edu.umd.lib.camel.routes.fixity.SuccessDistribution">
+      <from uri="direct:fixity.SuccessDistribution"/>
       <multicast parallelProcessing="true">
-        <to uri="direct:fixity.log"/>
-        <to uri="direct:fixity.audit"/>
+        <to uri="direct:fixity.CreateLogfileEntry"/>
+        <to uri="direct:fixity.CreateAuditRecord"/>
       </multicast>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.FixityFailureDistribution">
-      <from uri="direct:fixity.failure"/>
+    <route id="edu.umd.lib.camel.routes.fixity.FailureDistribution">
+      <from uri="direct:fixity.FailureDistribution"/>
       <multicast parallelProcessing="true">
-        <to uri="direct:fixity.log"/>
-        <to uri="direct:fixity.audit"/>
-        <to uri="direct:fixity.notify"/>
+        <to uri="direct:fixity.CreateLogfileEntry"/>
+        <to uri="direct:fixity.CreateAuditRecord"/>
+        <to uri="direct:fixity.Notify"/>
       </multicast>
     </route>
 
@@ -157,8 +157,8 @@
     Produces body format:
     * application/n-triples
     -->
-    <route id="edu.umd.lib.camel.routes.FixityAudit">
-      <from uri="direct:fixity.audit"/>
+    <route id="edu.umd.lib.camel.routes.fixity.CreateAuditRecord">
+      <from uri="direct:fixity.CreateAuditRecord"/>
       <setHeader headerName="CamelAuditEventId">
         <groovy>"urn:uuid:" + UUID.randomUUID().toString()</groovy>
       </setHeader>
@@ -171,7 +171,7 @@
       <log loggingLevel="INFO" message="Fixity check event URI: ${header.CamelAuditEventUri}"/>
       <process ref="fixityAuditSparqlProcessor"/>
       <!-- produces an N-Triples formatted RDF document using the PREMIS vocabulary to describe the fixity check -->
-      <to uri="activemq:queue:audit.triplestore"/>
+      <to uri="activemq:audit.triplestore"/>
     </route>
 
     <!--
@@ -187,8 +187,8 @@
     Produces body format:
     * text/csv
     -->
-    <route id="edu.umd.lib.camel.routes.FixityLog">
-      <from uri="direct:fixity.log"/>
+    <route id="edu.umd.lib.camel.routes.fixity.CreateLogfileEntry">
+      <from uri="direct:fixity.CreateLogfileEntry"/>
       <process ref="fixityLogSparqlProcessor"/>
       <setHeader headerName="CamelFileName">
         <groovy><![CDATA[
@@ -209,8 +209,8 @@
     Expects beans:
     * repoExternalURL : java.net.URL
     -->
-    <route id="edu.umd.lib.camel.routes.FixityNotify">
-      <from uri="direct:fixity.notify"/>
+    <route id="edu.umd.lib.camel.routes.fixity.SendFailureNotification">
+      <from uri="direct:fixity.SendFailureNotification"/>
       <removeHeaders pattern="*" excludePattern="CamelFcrepoUri"/>
       <setHeader headerName="To">
         <constant>lib-fcrepo-notify@umd.edu</constant>
@@ -224,11 +224,11 @@
       <setHeader headerName="Content-Type">
         <constant>text/plain</constant>
       </setHeader>
-      <!-- use a routing slip instead of a simple <to> element
+      <!-- use a recipient list instead of a simple <to> element
            for runtime configuration of the SMTP server address -->
-      <routingSlip>
+      <recipientList>
         <simple>smtp://${sysenv.SMTP_SERVER}</simple>
-      </routingSlip>
+      </recipientList>
     </route>
 
   </routeContext>

--- a/activemq/conf/camel/indexing.xml
+++ b/activemq/conf/camel/indexing.xml
@@ -3,7 +3,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-  <camelContext xmlns="http://camel.apache.org/schema/spring" id="Indexing" streamCache="true">
+  <routeContext xmlns="http://camel.apache.org/schema/spring" id="Indexing">
     <route id="edu.umd.lib.camel.routes.indexing.Intake">
       <from uri="activemq:queue:index"/>
       <choice>
@@ -33,5 +33,5 @@
       </setHeader>
       <to uri="activemq:queue:index"/>
     </route>
-  </camelContext>
+  </routeContext>
 </beans>

--- a/activemq/conf/camel/indexing.xml
+++ b/activemq/conf/camel/indexing.xml
@@ -4,8 +4,8 @@
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
   <routeContext xmlns="http://camel.apache.org/schema/spring" id="Indexing">
-    <route id="edu.umd.lib.camel.routes.indexing.Intake">
-      <from uri="activemq:queue:index"/>
+    <route id="edu.umd.lib.camel.routes.queue.index">
+      <from uri="activemq:index"/>
       <choice>
         <when>
           <header>CamelFcrepoIndexingDestinations</header>
@@ -17,21 +17,21 @@
         <otherwise>
           <log loggingLevel="DEBUG" message="Sending to all indexing destinations"/>
           <multicast parallelProcessing="true">
-            <to uri="activemq:queue:index.triplestore"/>
-            <to uri="activemq:queue:index.solr"/>
+            <to uri="activemq:index.triplestore"/>
+            <to uri="activemq:index.solr"/>
           </multicast>
         </otherwise>
       </choice>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.indexing.Reindex">
-      <from uri="activemq:queue:reindex"/>
+    <route id="edu.umd.lib.camel.routes.queue.reindex">
+      <from uri="activemq:reindex"/>
       <log loggingLevel="INFO" message="Reindexing resource ${header.CamelFcrepoUri}"/>
       <!-- a request to reindex should be treated the same as if the resource was updated -->
       <setHeader headerName="CamelFcrepoEventName">
         <constant>update</constant>
       </setHeader>
-      <to uri="activemq:queue:index"/>
+      <to uri="activemq:index"/>
     </route>
   </routeContext>
 </beans>

--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -20,8 +20,8 @@
     Expected environment variables:
     * BATCH_USER
     -->
-    <route id="edu.umd.lib.camel.routes.FedoraEvents">
-      <from uri="activemq:queue:fedora"/>
+    <route id="edu.umd.lib.camel.routes.queue.fedora">
+      <from uri="activemq:fedora"/>
       <process ref="eventProcessor"/>
       <setHeader headerName="CamelFcrepoUser">
         <header>org.fcrepo.jms.user</header>
@@ -69,10 +69,10 @@
         <when>
           <simple>${header.CamelFcrepoUser} == ${sysenv.BATCH_USER}</simple>
           <log loggingLevel="INFO" message="Detected batch user (${header.CamelFcrepoUser}) initiated event."/>
-          <to uri="direct:batch"/>
+          <to uri="direct:BatchEvent"/>
         </when>
         <otherwise>
-          <to uri="direct:detectEventType"/>
+          <to uri="direct:DetectEventType"/>
         </otherwise>
       </choice>
     </route>
@@ -82,8 +82,8 @@
     * CamelFcrepoPath
     * CamelFcrepoResourceType
     -->
-    <route id="edu.umd.lib.camel.routes.BatchEvents">
-      <from uri="direct:batch"/>
+    <route id="edu.umd.lib.camel.routes.BatchEvent">
+      <from uri="direct:BatchEvent"/>
       <filter>
         <simple>${header.CamelFcrepoPath} contains '#'</simple>
         <log loggingLevel="DEBUG" message="URI with fragment detected. Suppressing '${header.CamelFcrepoUri}' node event for batch user."/>
@@ -100,7 +100,7 @@
       <setHeader headerName="UMDBatchEvent">
         <constant>true</constant>
       </setHeader>
-      <to uri="direct:detectEventType"/>
+      <to uri="direct:DetectEventType"/>
     </route>
 
     <!--
@@ -109,7 +109,7 @@
     * CamelFcrepoUserAgent
     -->
     <route id="edu.umd.lib.camel.routes.DetectEventType">
-      <from uri="direct:detectEventType"/>
+      <from uri="direct:DetectEventType"/>
       <log loggingLevel="DEBUG" message="${routeId}: ${id}"/>
 
       <choice>
@@ -152,7 +152,7 @@
         </when>
       </choice>
 
-      <to uri="direct:detectBinary"/>
+      <to uri="direct:DetectBinary"/>
     </route>
 
     <!--
@@ -161,7 +161,7 @@
     * CamelFcrepoEventName
     -->
     <route id="edu.umd.lib.camel.routes.DetectBinary">
-      <from uri="direct:detectBinary"/>
+      <from uri="direct:DetectBinary"/>
       <choice>
         <when>
           <simple>${header.CamelFcrepoResourceType} contains "http://fedora.info/definitions/v4/repository#Binary"</simple>
@@ -179,7 +179,7 @@
         </otherwise>
       </choice>
       <log loggingLevel="INFO" message="Event with MessageID ${id} is a ${headers.CamelFcrepoEventName} event"/>
-      <to uri="direct:distribution"/>
+      <to uri="direct:Distribution"/>
     </route>
 
     <!--
@@ -187,15 +187,15 @@
     * CamelFcrepoUri
     -->
     <route id="edu.umd.lib.camel.routes.Distribution">
-      <from uri="direct:distribution"/>
+      <from uri="direct:Distribution"/>
       <log loggingLevel="DEBUG" message="Distributing event for ${header.CamelFcrepoUri} (MessageID: ${id})"/>
       <multicast parallelProcessing="true">
         <filter>
           <simple>${headers.CamelFcrepoBinary}</simple>
-          <to uri="direct:binary"/>
+          <to uri="direct:BinaryDistribution"/>
         </filter>
-        <to uri="activemq:queue:index"/>
-        <to uri="activemq:queue:audit"/>
+        <to uri="activemq:index"/>
+        <to uri="activemq:audit"/>
       </multicast>
     </route>
 
@@ -204,8 +204,8 @@
     * CamelFcrepoEventName
     * CamelFcrepoUri
     -->
-    <route id="edu.umd.lib.camel.routes.Binaries">
-      <from uri="direct:binary"/>
+    <route id="edu.umd.lib.camel.routes.BinaryDistribution">
+      <from uri="direct:BinaryDistribution"/>
       <multicast parallelProcessing="true">
         <pipeline>
           <removeHeaders pattern="CamelHttp*"/>
@@ -232,7 +232,7 @@
             <setBody>
               <constant/>
             </setBody>
-            <to uri="activemq:queue:images"/>
+            <to uri="activemq:images"/>
           </filter>
         </pipeline>
         <filter>
@@ -250,7 +250,7 @@
           <to uri="activemq:queue:fixitycandidates"/>
         </filter>
         <!-- send to fixity processing -->
-        <to uri="activemq:queue:fixity"/>
+        <to uri="activemq:fixity"/>
       </multicast>
     </route>
 

--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -5,8 +5,7 @@
 
   <bean id="eventProcessor" class="org.fcrepo.camel.processor.EventProcessor"/>
 
-  <camelContext xmlns="http://camel.apache.org/schema/spring" id="UmdFcrepoEventRouter" streamCache="true">
-
+  <routeContext xmlns="http://camel.apache.org/schema/spring" id="EventProcessing">
     <!--
     Expected headers:
     * org.fcrepo.jms.user
@@ -255,5 +254,5 @@
       </multicast>
     </route>
 
-  </camelContext>
+  </routeContext>
 </beans>

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -114,12 +114,12 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
   </bean>
 
   <routeContext xmlns="http://camel.apache.org/schema/spring" id="Solr">
-    <route id="edu.umd.lib.camel.routes.SolrIndexFilter">
+    <route id="edu.umd.lib.camel.routes.queue.index.solr">
       <description>Does initial filtering of event messages to only process resources
       with the RDF types `pcdm:Object`, `pcdm:File`, `pcdm:Collection`, `oa:Annotation`,
       or `ore:Proxy`. Those event messages are routed to both the new and the legacy
       Solr indexing processors (Solrizer and LDPath, respectively).</description>
-      <from uri="activemq:queue:index.solr"/>
+      <from uri="activemq:index.solr"/>
       <choice>
         <when>
           <description>resource is a PCDM, OA, or ORE resource</description>
@@ -132,8 +132,8 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           </simple>
           <log loggingLevel="INFO" message="${header.CamelFcrepoUri} has a recognized RDF type for Solr indexing"/>
           <multicast parallelProcessing="true">
-            <to uri="direct:index.solr.legacy"/>
-            <to uri="direct:index.solr"/>
+            <to uri="direct:solr.LegacyIndex"/>
+            <to uri="direct:solr.Index"/>
           </multicast>
         </when>
         <otherwise>
@@ -143,11 +143,11 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       </choice>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.LegacySolrIndex">
+    <route id="edu.umd.lib.camel.routes.solr.LegacyIndex">
       <description>Main route for adding, updating, or removing resources from the
         legacy Solr `fedora4` index. Uses a Java LDPath processor to convert the resource's
         RDF to a JSON Solr document.</description>
-      <from uri="direct:index.solr.legacy"/>
+      <from uri="direct:solr.LegacyIndex"/>
 
       <setHeader headerName="SolrUpdateEndpoint">
         <simple>${sysenv.LEGACY_SOLR_UPDATE_ENDPOINT}</simple>
@@ -156,22 +156,20 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         <when>
           <description>delete event</description>
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
-          <to uri="direct:solr.delete"/>
+          <to uri="direct:solr.DeleteFromIndex"/>
         </when>
         <otherwise>
-          <to uri="direct:solr.ldpath"/>
-          <to uri="direct:solr.add"/>
+          <to uri="direct:solr.LDPath"/>
+          <to uri="direct:solr.AddToIndex"/>
         </otherwise>
       </choice>
-
-      <to uri="direct:solr.update"/>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.SolrIndex">
+    <route id="edu.umd.lib.camel.routes.solr.Index">
       <description>Main route for adding, updating, or removing resources from the
       Solr `fcrepo` index. Uses the Solrizer HTTP microservice to convert the resource's
       RDF to a JSON Solr document.</description>
-      <from uri="direct:index.solr"/>
+      <from uri="direct:solr.Index"/>
 
       <setHeader headerName="SolrUpdateEndpoint">
         <simple>${sysenv.SOLR_UPDATE_ENDPOINT}</simple>
@@ -180,9 +178,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         <when>
           <description>delete event</description>
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
-          <to uri="direct:solr.delete"/>
-          <to uri="direct:solr.update"/>
-          <log loggingLevel="INFO" message="Removed ${header.CamelFcrepoUri} from ${header.SolrUpdateEndpoint}"/>
+          <to uri="direct:solr.DeleteFromIndex"/>
         </when>
         <when>
           <description>import event</description>
@@ -190,37 +186,51 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <!-- filter out non-top-level resources when indexing after an import
                since Solrizer will include the child resources itself -->
           <filter>
+            <description>is a top-level resource</description>
             <simple>${header.UMDIsTopLevelResource}</simple>
-            <to uri="direct:solr.solrizer"/>
-            <to uri="direct:solr.add"/>
-            <to uri="direct:solr.update"/>
-            <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
+            <to uri="direct:solr.Solrizer"/>
+            <to uri="direct:solr.AddToIndex"/>
           </filter>
         </when>
         <when>
           <description>create event</description>
           <simple>${header.CamelFcrepoEventName} starts with "create"</simple>
-          <to uri="direct:solr.solrizer"/>
-          <to uri="direct:solr.add"/>
-          <to uri="direct:solr.update"/>
-          <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
+          <to uri="direct:solr.Solrizer"/>
+          <to uri="direct:solr.AddToIndex"/>
         </when>
         <when>
           <description>update event</description>
           <simple>${header.CamelFcrepoEventName} starts with "update"</simple>
-          <to uri="direct:solr.solrizer"/>
-          <to uri="direct:solr.add"/>
-          <to uri="direct:solr.update"/>
-          <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
+          <to uri="direct:solr.Solrizer"/>
+          <to uri="direct:solr.AddToIndex"/>
         </when>
       </choice>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.LDPathTransformation">
+    <route id="edu.umd.lib.camel.routes.solr.AddToIndex">
+      <description>Pipeline route to add the Solr document in the current
+        message body to the Solr index at the HTTP endpoint given in the
+        `SolrUpdateEndpoint` header.</description>
+      <from uri="direct:solr.AddToIndex"/>
+      <to uri="direct:solr.CreateAddCommand"/>
+      <to uri="direct:solr.SendUpdate"/>
+      <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
+    </route>
+
+    <route id="edu.umd.lib.camel.routes.solr.DeleteFromIndex">
+      <description>Pipeline route to delete from Solr a document whose `id`
+        is given in the `CamelFcrepoUri` header.</description>
+      <from uri="direct:solr.DeleteFromIndex"/>
+      <to uri="direct:solr.CreateDeleteCommand"/>
+      <to uri="direct:solr.SendUpdate"/>
+      <log loggingLevel="INFO" message="Removed ${header.CamelFcrepoUri} from ${header.SolrUpdateEndpoint}"/>
+    </route>
+
+    <route id="edu.umd.lib.camel.routes.solr.LDPath">
       <description>Uses LDPath and the `indexingLDPathProcessor` to transform
         the resource at the URL constructed from the `REPO_INTERNAL_URL`
         environment variable and the `CamelFcrepoPath` header.</description>
-      <from uri="direct:solr.ldpath"/>
+      <from uri="direct:solr.LDPath"/>
 
       <setHeader headerName="CamelHttpUri">
         <simple>${sysenv.REPO_INTERNAL_URL}${header.CamelFcrepoPath}</simple>
@@ -232,7 +242,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       <log loggingLevel="INFO" message="Finished LDPath processing of ${header.CamelFcrepoUri}"/>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.Solrizer">
+    <route id="edu.umd.lib.camel.routes.solr.Solrizer">
       <description>Uses the Solrizer service located at the URL given in the
         `SOLRIZER_ENDPOINT` environment variable to set the message body to the
         content of a Solr document in JSON format for the resource with the URI
@@ -251,11 +261,12 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       <log loggingLevel="INFO" message="Finished Solrizer processing of ${header.CamelFcrepoUri}"/>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.SolrDocToSolrAddCommand">
+    <route id="edu.umd.lib.camel.routes.solr.CreateAddCommand">
       <description>Creates a Solr "add" command in JSON format by wrapping
         the existing message body (assumed to be in JSON format) in a
-        `{"add": {"doc": {...}}}` structure.</description>
-      <from uri="direct:solr.add"/>
+        `{"add": {"doc": {...}}}` structure. Also sets the `Content-Type`
+        header to `application/json`.</description>
+      <from uri="direct:solr.CreateAddCommand"/>
 
       <log loggingLevel="DEBUG" message="Creating Solr add command for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="Content-Type">
@@ -266,10 +277,11 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       </setBody>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.DeleteEventToSolrDeleteCommand">
+    <route id="edu.umd.lib.camel.routes.solr.CreateDeleteCommand">
       <description>Creates a Solr "delete" command in JSON format for the
-        resource with the `id` found in the `CamelFcrepoUri` header.</description>
-      <from uri="direct:solr.delete"/>
+        resource with the `id` found in the `CamelFcrepoUri` header. Also
+        sets the `Content-Type` header to `application/json`.</description>
+      <from uri="direct:solr.CreateDeleteCommand"/>
 
       <log loggingLevel="DEBUG" message="Creating Solr delete command for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="Content-Type">
@@ -280,10 +292,10 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       </setBody>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.SendSolrUpdate">
+    <route id="edu.umd.lib.camel.routes.solr.SendUpdate">
       <description>Sends a Solr command (in the message body) to the URL in the
         `SolrUpdateEndpoint` header as an HTTP POST request.</description>
-      <from uri="direct:solr.update"/>
+      <from uri="direct:solr.SendUpdate"/>
 
       <log loggingLevel="DEBUG" message="Sending ${body} to ${header.SolrUpdateEndpoint}"/>
 

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -3,19 +3,6 @@
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-  <!-- bean id="deadLetterProcessor" class="edu.umd.lib.camel.processors.DeadLetterProcessor"/>
-
-  <bean id="deadLetterErrorHandler" class="org.apache.camel.builder.DeadLetterChannelBuilder">
-    <property name="deadLetterUri" value="activemq:queue:dead"/>
-    <property name="redeliveryPolicy" ref="redeliveryPolicyConfig"/>
-    <property name="onPrepareFailure" ref="deadLetterProcessor"/>
-  </bean>
-
-  <bean id="redeliveryPolicyConfig" class="org.apache.camel.processor.RedeliveryPolicy">
-    <property name="maximumRedeliveries" value="0"/>
-    <property name="redeliveryDelay" value="5000"/>
-  </bean -->
-
   <bean id="indexingLDPathProcessor" class="edu.umd.lib.camel.processors.LdpathProcessor">
     <property name="query">
       <value><![CDATA[
@@ -126,7 +113,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
     </property>
   </bean>
 
-  <camelContext xmlns="http://camel.apache.org/schema/spring" id="SolrIndex" streamCache="true"><!-- errorHandlerRef="deadLetterErrorHandler" -->
+  <routeContext xmlns="http://camel.apache.org/schema/spring" id="Solr">
     <route id="edu.umd.lib.camel.routes.SolrIndexFilter">
       <description>Does initial filtering of event messages to only process resources
       with the RDF types `pcdm:Object`, `pcdm:File`, `pcdm:Collection`, `oa:Annotation`,
@@ -195,6 +182,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
           <to uri="direct:solr.delete"/>
           <to uri="direct:solr.update"/>
+          <log loggingLevel="INFO" message="Removed ${header.CamelFcrepoUri} from ${header.SolrUpdateEndpoint}"/>
         </when>
         <when>
           <description>import event</description>
@@ -206,6 +194,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
             <to uri="direct:solr.solrizer"/>
             <to uri="direct:solr.add"/>
             <to uri="direct:solr.update"/>
+            <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
           </filter>
         </when>
         <when>
@@ -214,6 +203,15 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <to uri="direct:solr.solrizer"/>
           <to uri="direct:solr.add"/>
           <to uri="direct:solr.update"/>
+          <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
+        </when>
+        <when>
+          <description>update event</description>
+          <simple>${header.CamelFcrepoEventName} starts with "update"</simple>
+          <to uri="direct:solr.solrizer"/>
+          <to uri="direct:solr.add"/>
+          <to uri="direct:solr.update"/>
+          <log loggingLevel="INFO" message="Indexed ${header.CamelFcrepoUri} to ${header.SolrUpdateEndpoint}"/>
         </when>
       </choice>
     </route>
@@ -259,7 +257,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         `{"add": {"doc": {...}}}` structure.</description>
       <from uri="direct:solr.add"/>
 
-      <log loggingLevel="INFO" message="Creating Solr add command for ${header.CamelFcrepoUri}"/>
+      <log loggingLevel="DEBUG" message="Creating Solr add command for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="Content-Type">
         <constant>application/json</constant>
       </setHeader>
@@ -273,7 +271,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         resource with the `id` found in the `CamelFcrepoUri` header.</description>
       <from uri="direct:solr.delete"/>
 
-      <log loggingLevel="INFO" message="Creating Solr delete command for ${header.CamelFcrepoUri}"/>
+      <log loggingLevel="DEBUG" message="Creating Solr delete command for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="Content-Type">
         <constant>application/json</constant>
       </setHeader>
@@ -300,6 +298,6 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       <to uri="http4://solr"/>
     </route>
 
-  </camelContext>
+  </routeContext>
 
 </beans>

--- a/activemq/conf/camel/triplestore.xml
+++ b/activemq/conf/camel/triplestore.xml
@@ -5,7 +5,7 @@
 
   <bean id="descriptionURI" class="edu.umd.lib.camel.processors.DescriptionURI"/>
 
-  <camelContext xmlns="http://camel.apache.org/schema/spring" id="Triplestore" streamCache="true">
+  <routeContext xmlns="http://camel.apache.org/schema/spring" id="Triplestore">
     <!--
     Expected headers:
     * CamelFcrepoEventName
@@ -157,5 +157,5 @@ WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
       <log loggingLevel="DEBUG" message="SPARQL Update Query: ${body}"/>
       <to uri="http4:triplestore"/>
     </route>
-  </camelContext>
+  </routeContext>
 </beans>

--- a/activemq/conf/camel/triplestore.xml
+++ b/activemq/conf/camel/triplestore.xml
@@ -3,7 +3,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-  <bean id="descriptionURI" class="edu.umd.lib.camel.processors.DescriptionURI"/>
+  <bean id="getDescriptionURI" class="edu.umd.lib.camel.processors.DescriptionURI"/>
 
   <routeContext xmlns="http://camel.apache.org/schema/spring" id="Triplestore">
     <!--
@@ -12,20 +12,25 @@
     Expected body format:
     * (None)
     -->
-    <route id="edu.umd.lib.camel.routes.TriplestoreIndexing">
-      <from uri="activemq:queue:index.triplestore"/>
+    <route id="edu.umd.lib.camel.routes.queue.index.triplestore">
+      <description>Distributes this message based on the type of event it represents.</description>
+      <from uri="activemq:index.triplestore"/>
       <choice>
         <when>
           <simple>${header.CamelFcrepoEventName} starts with "create"</simple>
-          <to uri="direct:index.triplestore.create"/>
+          <to uri="direct:triplestore.Create"/>
+        </when>
+        <when>
+          <simple>${header.CamelFcrepoEventName} starts with "import"</simple>
+          <to uri="direct:triplestore.Create"/>
         </when>
         <when>
           <simple>${header.CamelFcrepoEventName} starts with "update"</simple>
-          <to uri="direct:index.triplestore.update"/>
+          <to uri="direct:triplestore.Update"/>
         </when>
         <when>
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
-          <to uri="direct:index.triplestore.delete"/>
+          <to uri="direct:triplestore.Delete"/>
         </when>
       </choice>
     </route>
@@ -41,10 +46,15 @@
     Expected beans:
     * repoExternalURL
     -->
-    <route id="edu.umd.lib.camel.routes.GetRDF">
-      <from uri="direct:getRDF"/>
+    <route id="edu.umd.lib.camel.routes.triplestore.GetRDF">
+      <description>Retrieve the N-Triples representation of the resource with
+        the URI given in the `CamelFcrepoUri` header.</description>
+      <from uri="direct:triplestore.GetRDF"/>
       <!-- generate a Bearer auth token for the Authorization header -->
-      <process ref="addBearerAuthorization"/>
+      <process ref="addBearerAuthorization">
+        <description>add an Authorization header
+          containing a Bearer token</description>
+      </process>
       <!-- check whether this is a binary or not -->
       <setHeader headerName="CamelHttpUri">
         <simple>${sysenv.REPO_INTERNAL_URL}${header.CamelFcrepoPath}</simple>
@@ -56,9 +66,9 @@
       <log loggingLevel="DEBUG" message="HEAD ${header.CamelHttpUri}"/>
       <to uri="http4:fcrepo"/>
       <!-- parse the Link headers to check for rel="describedby" -->
-      <process ref="descriptionURI"/>
+      <process ref="getDescriptionURI"/>
       <filter>
-        <simple>${header.DescribedBy}</simple>
+        <header>DescribedBy</header>
         <setHeader headerName="CamelHttpUri">
           <header>DescribedBy</header>
         </setHeader>
@@ -87,14 +97,18 @@
     Expected body format:
     * N-Triples
     -->
-    <route id="edu.umd.lib.camel.routes.IndexTriplestoreCreate">
-      <from uri="direct:index.triplestore.create"/>
-      <to uri="direct:getRDF"/>
-      <!-- insert into the triplestore -->
+    <route id="edu.umd.lib.camel.routes.triplestore.Create">
+      <description>Generate an `INSERT DATA` SPARQL Update query wrapper
+        around the body of this message. The incoming body must be in
+        N-Triples format. The message is then forwarded to the
+        `triplestore.Submit` route.</description>
+
+      <from uri="direct:triplestore.Create"/>
+      <to uri="direct:triplestore.GetRDF"/>
       <setBody>
         <simple>INSERT DATA {\n${body}}</simple>
       </setBody>
-      <to uri="direct:index.triplestore.http"/>
+      <to uri="direct:triplestore.Submit"/>
     </route>
 
     <!--
@@ -103,9 +117,16 @@
     Expected body format:
     * N-Triples
     -->
-    <route id="edu.umd.lib.camel.routes.IndexTriplestoreUpdate">
-      <from uri="direct:index.triplestore.update"/>
-      <to uri="direct:getRDF"/>
+    <route id="edu.umd.lib.camel.routes.triplestore.Update">
+      <description>Generate a `DELETE {...} INSERT {...}` SPARQL Update
+        query. The `DELETE` clause will remove all triples with a subject
+        URI equal to the `CamelFcrepoUri` header. The `INSERT` clause
+        wraps the body of this message. The incoming body must be in
+        N-Triples format. The message is then forwarded to the
+        `triplestore.Submit` route.</description>
+
+      <from uri="direct:triplestore.Update"/>
+      <to uri="direct:triplestore.GetRDF"/>
       <!-- replace current triples in triplestore -->
       <setBody>
         <simple><![CDATA[
@@ -113,7 +134,7 @@ DELETE { <${header.CamelFcrepoUri}> ?p ?o }
 INSERT {\n${body}}
 WHERE {}]]></simple>
       </setBody>
-      <to uri="direct:index.triplestore.http"/>
+      <to uri="direct:triplestore.Submit"/>
     </route>
 
     <!--
@@ -122,8 +143,16 @@ WHERE {}]]></simple>
     Expected body format:
     * N-Triples
     -->
-    <route id="edu.umd.lib.camel.routes.IndexTriplestoreDelete">
-      <from uri="direct:index.triplestore.delete"/>
+    <route id="edu.umd.lib.camel.routes.triplestore.Delete">
+      <description>Generate a `DELETE {...} INSERT {...} WHERE {...}`
+        SPARQL Update query. The `DELETE` clause will remove all
+        triples with a subject URI equal to the `CamelFcrepoUri`
+        header. The `INSERT` clause does nothing. The `WHERE` clause
+        simply limits the update to the set of triples that have
+        a subject URI equal to the `CamelFcrepoUri` header. The
+        message is then forwarded to the `triplestore.Submit`
+        route.</description>
+      <from uri="direct:triplestore.Delete"/>
       <setBody>
         <simple><![CDATA[
 DELETE { <${header.CamelFcrepoUri}> ?p ?o }
@@ -131,7 +160,7 @@ INSERT {}
 WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
         ]]></simple>
       </setBody>
-      <to uri="direct:index.triplestore.http"/>
+      <to uri="direct:triplestore.Submit"/>
     </route>
 
     <!--
@@ -142,8 +171,13 @@ WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
     Expected environment variables:
     * INDEX_TRIPLESTORE_UPDATE_URI
     -->
-    <route id="edu.umd.lib.camel.routes.IndexTriplestoreHttp">
-      <from uri="direct:index.triplestore.http"/>
+    <route id="edu.umd.lib.camel.routes.triplestore.Submit">
+      <description>Submit the message body (assumed to be in
+        `application/sparql-update` format) via HTTP POST to
+        the URI from given by the environment variable
+        `INDEX_TRIPLESTORE_UPDATE_URI`</description>
+
+      <from uri="direct:triplestore.Submit"/>
       <removeHeaders pattern="*"/>
       <setHeader headerName="CamelHttpUri">
         <simple>${sysenv.INDEX_TRIPLESTORE_UPDATE_URI}</simple>

--- a/docs/Camel.md
+++ b/docs/Camel.md
@@ -1,0 +1,41 @@
+# Camel
+
+This project uses [Apache Camel] to define message routing between
+persistent queues in [ActiveMQ], databases, HTTP services, and other
+endpoints.
+
+## Route Naming Conventions
+
+* All route IDs begin with `edu.umd.lib.camel.routes`
+* If a route's source is a queue, the ID should continue with `queue.`,
+  followed by the name of the queue. For example:
+  
+  ```xml
+  <route id="edu.umd.lib.camel.routes.queue.index.solr">
+    <from uri="activemq:index.solr"/>
+    <!-- ... -->
+  </route>
+  ```
+
+* If the route's source is a `direct:` endpoint, the ID should continue
+  with the name of that endpoint. For example:
+
+  ```xml
+  <route id="edu.umd.lib.camel.routes.solr.AddToIndex">
+    <from uri="direct:solr.AddToIndex"/>
+    <!-- ... -->
+  </route>
+  ```
+  
+## Endpoint Naming Conventions
+
+* `direct:` endpoint names should start with the basename of the XML
+  file they are defined in. For example, all the `direct:` endpoints
+  defined in [solr.xml](../activemq/conf/camel/solr.xml) start with
+  `solr`
+  * **Exception:** Endpoints in [routes.xml](../activemq/conf/camel/routes.xml)
+    do *not* start with `routes`, so that their corresponding routes
+    do not contain the string `routes.routes`
+
+[ActiveMQ]: https://activemq.apache.org/components/classic/
+[Camel]: https://camel.apache.org/

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
- catch any exception and route the messages to `activemq:errors.routes.{routeName}` with some additional debugging information:
  * exception message
  * exception stack trace
  * route in which the exception occurred
  * last destination endpoint
  * JMS correlation ID, for easy locating in the error queue via the ActiveMQ interface
- consolidate all routes into a single Camel Context; this will be required when upgrading to Camel 3+
- use the `routeContext` element to group the related routes; this allows for a single centralized exception handler
- removed old commented out error handler code
- standardized route and endpoint naming
- updated documentation

https://umd-dit.atlassian.net/browse/LIBFCREPO-1110