### PR TITLE
LIBFCREPO-1620. Added CamelFcrepoSolrIndexingDestinations header.

### DIFF
--- a/activemq/conf/camel/indexing.xml
+++ b/activemq/conf/camel/indexing.xml
@@ -9,19 +9,19 @@
       <choice>
         <when>
           <header>CamelFcrepoIndexingDestinations</header>
-          <log loggingLevel="DEBUG" message="Sending to ${header.CamelFcrepoIndexingDestinations}"/>
-          <recipientList ignoreInvalidEndpoints="true" parallelProcessing="true">
-            <header>CamelFcrepoIndexingDestinations</header>
-          </recipientList>
+          <log loggingLevel="DEBUG" message="CamelFcrepoIndexingDestinations header found: ${header.CamelFcrepoIndexingDestinations}"/>
         </when>
         <otherwise>
-          <log loggingLevel="DEBUG" message="Sending to all indexing destinations"/>
-          <multicast parallelProcessing="true">
-            <to uri="activemq:index.triplestore"/>
-            <to uri="activemq:index.solr"/>
-          </multicast>
+          <log loggingLevel="DEBUG" message="No CamelFcrepoIndexingDestinations header found, using default"/>
+          <setHeader headerName="CamelFcrepoIndexingDestinations">
+            <constant>activemq:index.triplestore,activemq:index.solr</constant>
+          </setHeader>
         </otherwise>
       </choice>
+      <log loggingLevel="INFO" message="Indexing destinations: ${header.CamelFcrepoIndexingDestinations}"/>
+      <recipientList ignoreInvalidEndpoints="true" parallelProcessing="true">
+        <header>CamelFcrepoIndexingDestinations</header>
+      </recipientList>
     </route>
 
     <route id="edu.umd.lib.camel.routes.queue.reindex">

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -131,10 +131,23 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
             || "http://www.openarchives.org/ore/terms/Proxy" in ${header.CamelFcrepoResourceType}
           </simple>
           <log loggingLevel="INFO" message="${header.CamelFcrepoUri} has a recognized RDF type for Solr indexing"/>
-          <multicast parallelProcessing="true">
-            <to uri="direct:solr.LegacyIndex"/>
-            <to uri="direct:solr.Index"/>
-          </multicast>
+          <choice>
+            <when>
+              <header>CamelFcrepoSolrIndexingDestinations</header>
+              <log loggingLevel="DEBUG" message="CamelFcrepoSolrIndexingDestinations header found: ${header.CamelFcrepoSolrIndexingDestinations}"/>
+            </when>
+            <otherwise>
+              <log loggingLevel="DEBUG" message="No CamelFcrepoSolrIndexingDestinations header found, using default"/>
+              <setHeader headerName="CamelFcrepoSolrIndexingDestinations">
+                <constant>direct:solr.LegacyIndex,direct:solr.Index</constant>
+              </setHeader>
+            </otherwise>
+          </choice>
+          <log loggingLevel="INFO" message="Solr indexing destinations: ${header.CamelFcrepoSolrIndexingDestinations}"/>
+          <recipientList ignoreInvalidEndpoints="true" parallelProcessing="true">
+            <description>One or more of: `direct:solr.Index`, `direct:solr.LegacyIndex`</description>
+            <header>CamelFcrepoSolrIndexingDestinations</header>
+          </recipientList>
         </when>
         <otherwise>
           <log loggingLevel="INFO" message="Skipping Solr indexing of ${header.CamelFcrepoUri} because it is not a recognized RDF type"/>
@@ -207,6 +220,15 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         <when>
           <description>update event</description>
           <simple>${header.CamelFcrepoEventName} starts with "update"</simple>
+          <setProperty propertyName="solrCommand">
+            <constant>update</constant>
+          </setProperty>
+          <to uri="direct:solr.Solrizer"/>
+          <to uri="direct:solr.SendUpdate"/>
+        </when>
+        <when>
+          <description>reindex event</description>
+          <simple>${header.CamelFcrepoEventName} starts with "reindex"</simple>
           <setProperty propertyName="solrCommand">
             <constant>update</constant>
           </setProperty>


### PR DESCRIPTION
- can take the values `direct:solr.Index` or `direct:solr.LegacyIndex` (or both) to trigger reindexing to either or both of the Solr indexes
- reworked the logic of the `CamelFcrepoIndexingDestinations` header to parallel the new `CamelFcrepoSolrIndexingDestinations` header
- added "reindex" event type

https://umd-dit.atlassian.net/browse/LIBFCREPO-1620