### PR TITLE
LIBFCREPO-1643. Removed `direct:solr.Index` from the default Solr indexing destinations.

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -139,7 +139,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
             <otherwise>
               <log loggingLevel="DEBUG" message="No CamelFcrepoSolrIndexingDestinations header found, using default"/>
               <setHeader headerName="CamelFcrepoSolrIndexingDestinations">
-                <constant>direct:solr.LegacyIndex,direct:solr.Index</constant>
+                <constant>direct:solr.LegacyIndex</constant>
               </setHeader>
             </otherwise>
           </choice>


### PR DESCRIPTION
https://umd-dit.atlassian.net/browse/LIBFCREPO-1643