### PR TITLE
LIBFCREPO-1705. Parallelization of Solrizer requests.

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -217,7 +217,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
             <setProperty propertyName="solrCommand">
               <constant>add</constant>
             </setProperty>
-            <to uri="direct:solr.Solrizer"/>
+            <to uri="seda:solr.Solrizer"/>
             <to uri="direct:solr.SendUpdate"/>
           </filter>
         </when>
@@ -227,7 +227,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <setProperty propertyName="solrCommand">
             <constant>add</constant>
           </setProperty>
-          <to uri="direct:solr.Solrizer"/>
+          <to uri="seda:solr.Solrizer"/>
           <to uri="direct:solr.SendUpdate"/>
         </when>
         <when>
@@ -236,7 +236,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <setProperty propertyName="solrCommand">
             <constant>update</constant>
           </setProperty>
-          <to uri="direct:solr.Solrizer"/>
+          <to uri="seda:solr.Solrizer"/>
           <to uri="direct:solr.SendUpdate"/>
         </when>
         <when>
@@ -245,7 +245,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <setProperty propertyName="solrCommand">
             <constant>update</constant>
           </setProperty>
-          <to uri="direct:solr.Solrizer"/>
+          <to uri="seda:solr.Solrizer"/>
           <to uri="direct:solr.SendUpdate"/>
         </when>
       </choice>
@@ -291,7 +291,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
         `SOLRIZER_ENDPOINT` environment variable to set the message body to the
         content of a Solr document in JSON format for the resource with the URI
         given in the `CamelFcrepoUri` header.</description>
-      <from uri="direct:solr.Solrizer"/>
+      <from uri="seda:solr.Solrizer?concurrentConsumers={{env:SOLRIZER_CONCURRENT_CONSUMERS:8}}"/>
 
       <removeHeaders pattern="CamelHttp*"/>
       <setHeader headerName="CamelHttpUri">


### PR DESCRIPTION
- use `seda` instead of `direct` endpoints
- set `concurrentConsumers` consumers of `seda:solr.Solrizer` to send concurrent HTTP requests to Solrizer
- read value from `SOLRIZER_CONCURRENT_CONSUMERS` default `concurrentConsumers` to 8

https://umd-dit.atlassian.net/browse/LIBFCREPO-1705 and https://umd-dit.atlassian.net/browse/LIBFCREPO-1718