### PR TITLE
LIBFCREPO-1758: Configure CamelHttpUri based on CamelFcrepoUserAgent

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -294,12 +294,26 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
       </choice>
 
       <removeHeaders pattern="CamelHttp*"/>
-      <setHeader headerName="CamelHttpUri">
-        <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}</simple>
-      </setHeader>
+
+      <choice>
+        <when>
+          <description>On Behalf Of header is a single user update</description>
+          <simple>${header.CamelFcrepoUserAgent} starts with "plastrond-http"</simple>
+          <setHeader headerName="CamelHttpUri">
+            <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}&amp;plastron-cache-enabled=no</simple>
+          </setHeader>
+        </when>
+        <otherwise>
+          <setHeader headerName="CamelHttpUri">
+            <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}</simple>
+          </setHeader>
+        </otherwise>
+      </choice>
+
       <setHeader headerName="CamelHttpMethod">
         <constant>GET</constant>
       </setHeader>
+
       <log loggingLevel="INFO" message="Started Solrizer processing of ${header.CamelFcrepoUri}"/>
       <log loggingLevel="DEBUG" message="Solrizer request URL: ${header.CamelHttpUri}"/>
       <to uri="http4://solrizer"/>

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -297,7 +297,7 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
 
       <choice>
         <when>
-          <description>On Behalf Of header is a single user update</description>
+          <description>Update initiated from plastrond-http</description>
           <simple>${header.CamelFcrepoUserAgent} starts with "plastrond-http"</simple>
           <setHeader headerName="CamelHttpUri">
             <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}&amp;plastron-cache-enabled=no</simple>


### PR DESCRIPTION
Use the CamelFcrepoUserAgent header to determine whether to disable caching for the plastron client in solrizer.

For now the plastron-http client is the one responsible for synchronous metadata editing and publishing, i.e. single resource updates.

We can check whether the user agent has "plastron-http" in it

https://umd-dit.atlassian.net/browse/LIBFCREPO-1758