### PR TITLE
LIBFCREPO-1759. Ensure top-level resources in /pcdm container get indexed.

### DIFF
--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -42,7 +42,7 @@
         <description>extracts the repo path from the top-level resource that the
         current resource is a part of (or is)</description>
         <groovy>
-          def match = (headers["CamelFcrepoPath"] =~ $/(/dc/\d{4}/\d+/../../../../.{8}-.{4}-.{4}-.{4}-.{12})/$)
+          def match = (headers["CamelFcrepoPath"] =~ $/((/dc/\d{4}/\d+|/pcdm)/../../../../.{8}-.{4}-.{4}-.{4}-.{12})/$)
           if (match) {
             result = match[0][1]
           }
@@ -51,6 +51,7 @@
       <setHeader headerName="UMDIsTopLevelResource">
         <simple resultType="java.lang.Boolean">${header.CamelFcrepoPath} == ${header.CamelFcrepoTopLevelResourcePath}</simple>
       </setHeader>
+      <log loggingLevel="DEBUG" message="${header.CamelFcrepoUri} is a top-level resource? ${header.UMDIsTopLevelResource}"/>
       <log loggingLevel="DEBUG" message="Event user: ${header.CamelFcrepoUser}"/>
       <log loggingLevel="DEBUG" message="Event user agent: ${header.CamelFcrepoUserAgent}"/>
       <log loggingLevel="INFO" message="Routing event for resource with URI: ${header.CamelFcrepoUri}"/>

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -291,35 +291,43 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
             <constant>update</constant>
           </setProperty>
         </when>
-      </choice>
-
-      <removeHeaders pattern="CamelHttp*"/>
-
-      <choice>
-        <when>
-          <description>Update initiated from plastrond-http</description>
-          <simple>${header.CamelFcrepoUserAgent} starts with "plastrond-http"</simple>
-          <setHeader headerName="CamelHttpUri">
-            <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}&amp;plastron-cache-enabled=no</simple>
-          </setHeader>
-        </when>
         <otherwise>
-          <setHeader headerName="CamelHttpUri">
-            <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}</simple>
-          </setHeader>
+          <log loggingLevel="ERROR" message="Unrecognized event: ${header.CamelFcrepoEventName}"/>
+          <stop/>
         </otherwise>
       </choice>
 
-      <setHeader headerName="CamelHttpMethod">
-        <constant>GET</constant>
-      </setHeader>
+      <filter>
+        <exchangeProperty>solrCommand</exchangeProperty>
 
-      <log loggingLevel="INFO" message="Started Solrizer processing of ${header.CamelFcrepoUri}"/>
-      <log loggingLevel="DEBUG" message="Solrizer request URL: ${header.CamelHttpUri}"/>
-      <to uri="http4://solrizer"/>
-      <log loggingLevel="DEBUG" message="Solrizer response: ${body}"/>
-      <log loggingLevel="INFO" message="Finished Solrizer processing of ${header.CamelFcrepoUri}"/>
-      <to uri="direct:solr.SendUpdate"/>
+        <removeHeaders pattern="CamelHttp*"/>
+
+        <choice>
+          <when>
+            <description>Update initiated from plastrond-http</description>
+            <simple>${header.CamelFcrepoUserAgent} starts with "plastrond-http"</simple>
+            <setHeader headerName="CamelHttpUri">
+              <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}&amp;plastron-cache-enabled=no</simple>
+            </setHeader>
+          </when>
+          <otherwise>
+            <setHeader headerName="CamelHttpUri">
+              <simple>${sysenv.SOLRIZER_ENDPOINT}?uri=${header.CamelFcrepoUri}&amp;command=${exchangeProperty.solrCommand}</simple>
+            </setHeader>
+          </otherwise>
+        </choice>
+
+        <setHeader headerName="CamelHttpMethod">
+          <constant>GET</constant>
+        </setHeader>
+
+        <log loggingLevel="INFO" message="Started Solrizer processing of ${header.CamelFcrepoUri}"/>
+        <log loggingLevel="DEBUG" message="Solrizer request URL: ${header.CamelHttpUri}"/>
+        <to uri="http4://solrizer"/>
+        <log loggingLevel="DEBUG" message="Solrizer response: ${body}"/>
+        <log loggingLevel="INFO" message="Finished Solrizer processing of ${header.CamelFcrepoUri}"/>
+        <to uri="direct:solr.SendUpdate"/>
+      </filter>
     </route>
 
     <route id="edu.umd.lib.camel.routes.solr.CreateAddCommand">


### PR DESCRIPTION
- include paths of the format `/pcdm/xx/xx/xx/xx/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` as top-level resources
- added additional logging
- stop processing through the solrizer route if the event type is not recognized
- only send to HTTP request to Solrizer if the `solrCommand` property has been set

https://umd-dit.atlassian.net/browse/LIBFCREPO-1759