### PR TITLE
LIBFCREPO-1811. Workaround: don't index resources updated during "attach" event.

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -206,6 +206,16 @@ handle = dcterms:identifier[^^umdtype:handle] :: xsd:string;
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
           <to uri="direct:solr.DeleteFromIndex"/>
         </when>
+        <when>
+          <description>append event</description>
+          <simple>${header.CamelFcrepoUserAgent} contains '(attach)'</simple>
+          <!-- Per LIBFCREPO-1811, we currently ignore events created by the plastron attach
+               command for the purpose of indexing since there is an error where the object
+               and page get deleted from Solr when the new file is added to Solr.
+               See https://umd-dit.atlassian.net/browse/LIBFCREPO-1811 -->
+          <log loggingLevel="WARN" message="Stopping indexing for ${header.CamelFcrepoUri} on attach event due to LIBFCREPO-1811 bug"/>
+          <stop/>
+        </when>
         <otherwise>
           <description>any other event</description>
           <to uri="activemq:solrizer"/>


### PR DESCRIPTION
This is a workaround for the problem where the object and page resources' Solr documents are getting erased during updates triggered by the plastron attach command. This means that after attaching files to the pages of an object, a manual reindex of the object is necessary to update it in Solr.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1811